### PR TITLE
NHK番組表APIのバージョンアップ（v2 to v3）

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,6 +64,7 @@ function find(date, keywords){
   const response = UrlFetchApp.fetch(url);
   const result = JSON.parse(response.getContentText());
   for(let channel in result){
+    const serviceName = result[channel].publishedOn[0].identifierGroup.shortenedDisplayName;
     for(let program of result[channel].publication){
       for(let keyword of keywords){
         if(program.name.includes(keyword)){
@@ -72,7 +73,7 @@ function find(date, keywords){
             continue;
           }
           dateAndNameOfFindings.push(dateAndName);
-          findings.push(getSummary(program));
+          findings.push(getSummary(program, serviceName));
         };
       }
     }
@@ -92,12 +93,9 @@ function pad(number){
   return number;
 }
 
-function getSummary(program){
+function getSummary(program, serviceName){
   // APIが返す日時文字列（例 "2023-06-20T06:00:00+09:00"）から時刻を切り出す
   const startTime = program.startDate.substring(11, 11 + 8);
-  // サービス名共通の接頭辞「NHK」を除く
-  // const serviceName = program.service.name.substring(3);
-  const serviceName = program.identifierGroup.serviceId; // 暫定対応
   return {
     startDatetime: new Date(program.startDate),
     toString: () => `- ${startTime} [${serviceName}] ${program.name}`,

--- a/main.js
+++ b/main.js
@@ -63,10 +63,10 @@ function find(date, keywords){
   const url = `https://program-api.nhk.jp/v3/papiPgDateTv?service=${SERVICE}&area=${AREA}&date=${date}&key=${APIKEY}`;
   const response = UrlFetchApp.fetch(url);
   const result = JSON.parse(response.getContentText());
-  for(let channel in result.list){
-    for(let program of result.list[channel]){
+  for(let channel in result){
+    for(let program of result[channel].publication){
       for(let keyword of keywords){
-        if(program.title.includes(keyword)){
+        if(program.name.includes(keyword)){
           if(idsOfFindings.includes(program.id)){
             continue;
           }
@@ -93,11 +93,12 @@ function pad(number){
 
 function getSummary(program){
   // APIが返す日時文字列（例 "2023-06-20T06:00:00+09:00"）から時刻を切り出す
-  const startTime = program.start_time.substring(11, 11 + 8);
+  const startTime = program.startDate.substring(11, 11 + 8);
   // サービス名共通の接頭辞「NHK」を除く
-  const serviceName = program.service.name.substring(3);
+  // const serviceName = program.service.name.substring(3);
+  const serviceName = program.identifierGroup.serviceId; // 暫定対応
   return {
-    startDatetime: new Date(program.start_time),
-    toString: () => `- ${startTime} [${serviceName}] ${program.title}`,
+    startDatetime: new Date(program.startDate),
+    toString: () => `- ${startTime} [${serviceName}] ${program.name}`,
   }
 }

--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ function main() {
 function find(date, keywords){
   const findings = [];
   const idsOfFindings = [];
-  const url = `https://program-api.nhk.jp/v3/papiPgDateTv?service=${SERVICE}&area=${AREA}&date=${date}&key=${APIKEY}`
+  const url = `https://program-api.nhk.jp/v3/papiPgDateTv?service=${SERVICE}&area=${AREA}&date=${date}&key=${APIKEY}`;
   const response = UrlFetchApp.fetch(url);
   const result = JSON.parse(response.getContentText());
   for(let channel in result.list){

--- a/main.js
+++ b/main.js
@@ -59,7 +59,7 @@ function main() {
 
 function find(date, keywords){
   const findings = [];
-  const idsOfFindings = [];
+  const dateAndNameOfFindings = [];
   const url = `https://program-api.nhk.jp/v3/papiPgDateTv?service=${SERVICE}&area=${AREA}&date=${date}&key=${APIKEY}`;
   const response = UrlFetchApp.fetch(url);
   const result = JSON.parse(response.getContentText());
@@ -67,10 +67,11 @@ function find(date, keywords){
     for(let program of result[channel].publication){
       for(let keyword of keywords){
         if(program.name.includes(keyword)){
-          if(idsOfFindings.includes(program.id)){
+          const dateAndName = program.startDate + program.name;
+          if(dateAndNameOfFindings.includes(dateAndName)){
             continue;
           }
-          idsOfFindings.push(program.id);
+          dateAndNameOfFindings.push(dateAndName);
           findings.push(getSummary(program));
         };
       }

--- a/main.js
+++ b/main.js
@@ -60,7 +60,7 @@ function main() {
 function find(date, keywords){
   const findings = [];
   const idsOfFindings = [];
-  const url = `https://api.nhk.or.jp/v2/pg/list/${AREA}/${SERVICE}/${date}.json?key=${APIKEY}`;
+  const url = `https://program-api.nhk.jp/v3/papiPgDateTv?service=${SERVICE}&area=${AREA}&date=${date}&key=${APIKEY}`
   const response = UrlFetchApp.fetch(url);
   const result = JSON.parse(response.getContentText());
   for(let channel in result.list){


### PR DESCRIPTION
NHK番組表APIのv3が公開され（ 2026-01-13 ~ ）、v2の提供終了（ ~2026-02-12 ）が通知された。
https://api-portal.nhk.or.jp/

使用を継続するため、v3にバージョンアップする。